### PR TITLE
Minimum log level : warning (was error)

### DIFF
--- a/src/App/Bundle/Resources/config/monolog_gelf.yml
+++ b/src/App/Bundle/Resources/config/monolog_gelf.yml
@@ -2,7 +2,7 @@ monolog:
     handlers:
         gelf_fingers_crossed:
             type:          fingers_crossed
-            action_level:  error
+            action_level:  warning
             handler:       gelf
         gelf:
             type:   gelf


### PR DESCRIPTION
Warning messages wouldn't be caught by the `gelf_fingers_crossed` channel