### PR TITLE
inextensodigital/tech#99 - Add gelf handler in a ignore-failure group

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "psr-4": { "Xeonys\\LoggerExtra\\": "src/"}
     },
     "require": {
-        "php": ">=5.5"
+        "php": ">=5.5",
+        "symfony/monolog-bundle": "~2.7.0"
     },
     "suggest": {
         "monolog/monolog": "The good solution to write log in php.",

--- a/src/App/Bundle/Resources/config/monolog_gelf.yml
+++ b/src/App/Bundle/Resources/config/monolog_gelf.yml
@@ -1,5 +1,8 @@
 monolog:
     handlers:
+        ignore_failures:
+            type: whatfailuregroup
+            members: [gelf_fingers_crossed]
         gelf_fingers_crossed:
             type:          fingers_crossed
             action_level:  warning


### PR DESCRIPTION
Add gelf handler in a ignore-failure group to avoid processes to stop if we got an error when sending errors to ELK.